### PR TITLE
add namespacing support for widget cloning

### DIFF
--- a/common/wp-posttype-widget.php
+++ b/common/wp-posttype-widget.php
@@ -232,6 +232,7 @@ class WW_Widget_PostType {
       
       // let the widget update itself
       $classname = $_POST['ww-data']['clone']['clone-class'];
+      $classname = implode("\\", array_filter( explode( "\\", $classname )));
       if (class_exists($classname)) {
         $wp_widget = new $classname;
         $instance = $wp_widget->update($instance, $old_instance);
@@ -256,6 +257,7 @@ class WW_Widget_PostType {
     global $wp_widget_factory;
     if (isset($posted['ww-data']['clone'])) {
       $clone_class = $posted['ww-data']['clone']['clone-class'];
+      $clone_class = implode("\\", array_filter( explode( "\\", $clone_class )));
       $option_name = "widget-".$wp_widget_factory->widgets[$clone_class]->control_options['id_base'];
       $instance = array();
     


### PR DESCRIPTION
I use namespacing on my Widgets for PSR-4 autoloading. I noticed that because
1. We are using `<input>`s to get the class name
2. We are storing the class name in post meta
that the FQCN doesn't behave properly because of the namespace characters. This PR attempts to fix that for the cloning process.